### PR TITLE
CI: add simple ci job to test project build

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,45 @@
+name: CI - Build, Test, and Docker
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  # manual trigger (temporary)
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    name: Build, Test, and Docker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build the project
+        run: npm run build
+
+      - name: Lint the project
+        run: npm run lint
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build Docker image
+        run: docker build -t portfolio .
+
+      - name: Test Docker container
+        run: |
+          docker run -d -p 3000:3000 --name portfolio-test portfolio
+          sleep 5 # Wait for the container to start
+          curl -f http://localhost:3000 || exit 1
+          docker stop portfolio-test
+          docker rm portfolio-test


### PR DESCRIPTION
Based off of #1.

This would introduce a simple CI job to test the project build at each merge/PR on main. 